### PR TITLE
fix: handle falsy values in parameter serialization

### DIFF
--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -65,7 +65,7 @@ export class AEBaseClient implements AE_Base_Client {
 
       for (let i = 0; i < sorted.length; i++) {
         let symbol = i === 0 ? "?" : "&";
-        if (p[sorted[i] as keyof typeof p])
+        if (p[sorted[i] as keyof typeof p] !== undefined && p[sorted[i] as keyof typeof p] !== null)
           basestring +=
             symbol +
             sorted[i] +


### PR DESCRIPTION
The parameter `0 is being treated as a falsy value in the condition `if (p[sorted[i] as keyof typeof p])`. 

In JavaScript and TypeScript, 0 is considered falsy, so the condition fails and the parameter is not included in the `basestring`

Example:

```javascript
await affiliate_client.generateAffiliateLinks({
    promotion_link_type: 0,
    tracking_id: "default",
    source_values: "https://www.aliexpress.com",
  });
```

The `basestring` will returns `source_values=https%3A%2F%2Fwww.aliexpress.com&tracking_id=default`. It miss the `promotion_link_type=0`